### PR TITLE
new compressed size prediction function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2826,6 +2826,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "url",
 ]
 
 [[package]]

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -38,10 +38,5 @@ tokio.workspace = true
 toml.workspace = true
 tracing.workspace = true
 tracing-appender.workspace = true
-<<<<<<< HEAD
 tracing-subscriber.workspace = true
 url.workspace = true
-=======
-tracing-loki.workspace = true
-tracing-subscriber.workspace = true
->>>>>>> f1af11cc8a1f6ab5c5c8aa8eb8c713647f58145a


### PR DESCRIPTION
from:

pub fn estimate_compressed_size_simple(uncompressed_size: usize) -> usize {
    (COMPRESS_RATIO * uncompressed_size as f64).round() as usize
}

to:
pub fn estimate_compressed_size(uncompressed_size: usize) -> usize {
    let uncompressed_size_f64 = uncompressed_size as f64;
    let slope = 0.9881615963738659;
    let intercept = -0.19936358812829091;
    let predicted_size = (slope * uncompressed_size_f64.ln() + intercept).exp();
    predicted_size as usize
}

slope and intercept is obtained by taking the log from the server. plot the actual size over compressed size, then fit the line in log scale.

![image](https://github.com/user-attachments/assets/7ddf4a3c-4d86-4b18-92f4-bd060bcf4f1d)

blue is the data points from the log files
orange is the previous estimation function result
red line is the new estimation function result
